### PR TITLE
changed logger from root to bambuprinter

### DIFF
--- a/src/bpm/bambuprinterlogger.json
+++ b/src/bpm/bambuprinterlogger.json
@@ -37,7 +37,7 @@
       }
     },
     "loggers": {
-      "root": {
+      "bambuprinter": {
         "level": "DEBUG",
         "handlers": [
           "stderr",


### PR DESCRIPTION
The logger configuration file uses the "root" logger by default. However doing so makes it difficult for any other part of the Python program to use the logger (whether to output logs to your own files, change logger settings, or otherwise use any logger level below WARNING). It is possible to configure the logger configuration file to fix this, however this is buried in the packages directory and may be overwritten if updating the bpm pip package. I've instead changed the configuration file to use the "bambuprinter" logger directly, so only the logs generated by the bpm module are managed and output in this way.