### PR TITLE
fix: implementation requires paho-mqtt 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "webcolors",
-  "paho-mqtt",
+  "paho-mqtt>=2.1.0",
   "mkdocstrings-python",
   "typing-extensions ; python_version<'3.13'",
 ]


### PR DESCRIPTION
This should be pinned accordingly, or weird things will happen for users who happen to still have a paho-mqtt 1.x sitting in their venv.

I'm thinking this might be the reason for a connection error I just got reported on OctoPrint 2.0.0rc1's feedback ticket, see https://github.com/OctoPrint/OctoPrint/issues/5373#issuecomment-4335856351