### PR TITLE
fix: make quit work after connection loss

### DIFF
--- a/src/bpm/bambuprinter.py
+++ b/src/bpm/bambuprinter.py
@@ -269,9 +269,10 @@ class BambuPrinter:
         considered dead after making this call although you may be able to restart a
         session with [start_session](#bpm.bambuprinter.BambuPrinter.start_session)().
         """
-        if self.client and self.client.is_connected():
-            self.client.disconnect()
-            logger.debug("quit - mqtt client was connected and is now disconnected")
+        if self._client:
+            # always call disconnect as is_connected will return False in case of connection loss w/ retry
+            self._client.disconnect()
+            logger.debug("quit - mqtt client is now disconnected")
         else:
             logger.debug("quit - mqtt client was already disconnected")
 
@@ -279,6 +280,7 @@ class BambuPrinter:
         self._notify_update()
 
         if self._mqtt_client_thread and self._mqtt_client_thread.is_alive():
+            # this will block forever if the client hasn't been disconnected properly
             self._mqtt_client_thread.join()
         if self._watchdog_thread and self._watchdog_thread.is_alive():
             self._watchdog_thread.join()


### PR DESCRIPTION
Ran into an issue with the Bambu Connector Plugin for OctoPrint: when losing connection to the printer (e.g. because it was powered off), bpm stayed active and then caused issues if at some later point in time the printer returned. Easy fix, just react to the disconnect from MQTT and tell bpm to disconnect. However, that then got stuck in the thread `join` and everything hung for good. 

So I went digging and learned a lot about paho mqtt and its `loop_forever` method, which culminated in this fix.

A connection loss (printer goes offline) would formerly be seen as "client already disconnected" by bpm and thus the mqtt client wouldn't be told to disconnect. However, in the specific [state of an unexpected connection loss](https://github.com/eclipse-paho/paho.mqtt.python/blob/d45de3737879cfe7a6acc361631fa5cb1ef584bb/src/paho/mqtt/client.py#L1672) the mqtt client's `loop_forever` will continue to [attempt to reconnect forever](https://github.com/eclipse-paho/paho.mqtt.python/blob/d45de3737879cfe7a6acc361631fa5cb1ef584bb/src/paho/mqtt/client.py#L2308-L2328). So if we call `quit` after a disconnect, to close things for good, instead of actually disconnecting and ending the session, bpm will get stuck on the `join` as the mqtt client's `loop_forever` will never quit and thus the thread never end.

Making sure to always call `disconnect` on the mqtt client (if we have it) solves this.

I also switched to checking `self._client` here, as `self.client` always creates a new client (is that really intentionally? It feels wrong to me).